### PR TITLE
add universe/multiverse as a package source

### DIFF
--- a/stack/stack.toml
+++ b/stack/stack.toml
@@ -13,9 +13,9 @@ platforms = ["linux/amd64"]
 
   [build.args]
     sources = """
-    deb http://archive.ubuntu.com/ubuntu bionic main universe
-    deb http://archive.ubuntu.com/ubuntu bionic-updates main universe
-    deb http://archive.ubuntu.com/ubuntu bionic-security main universe
+    deb http://archive.ubuntu.com/ubuntu bionic main universe multiverse
+    deb http://archive.ubuntu.com/ubuntu bionic-updates main universe multiverse
+    deb http://archive.ubuntu.com/ubuntu bionic-security main universe multiverse
     """
 
     packages = """\
@@ -44,9 +44,9 @@ platforms = ["linux/amd64"]
 
   [run.args]
     sources = """
-    deb http://archive.ubuntu.com/ubuntu bionic main
-    deb http://archive.ubuntu.com/ubuntu bionic-updates main
-    deb http://archive.ubuntu.com/ubuntu bionic-security main
+    deb http://archive.ubuntu.com/ubuntu bionic main universe multiverse
+    deb http://archive.ubuntu.com/ubuntu bionic-updates main universe multiverse
+    deb http://archive.ubuntu.com/ubuntu bionic-security main universe multiverse
     """
 
     packages = """\


### PR DESCRIPTION
## Context
When we moved our stacks over we dropped the `multiverse` source from the stacks because we don't install any packages onto the stack ourselves from that repository out of security concern. Recently, we discovered that the compilation of the PHP dependency happens on a Bionic stack image, and then requires installing some extra packages from the Ubuntu `multiverse` repository to work. 

This PR adds the `multiverse` and `universe` sources back into the stack to enable use cases that leverage the stack with the addition of packages from these locations. **We will not be shipping any packages from the `multiverse` repository in the stacks themselves, and should not in the future.** This change is solely to enable others to do that.

In the future we should add some kind of test assertion here to ensure any new packages do not come from `multiverse`.
 
## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
